### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,3 +69,7 @@ Credits
  - Icons made by `Freepik <https://www.freepik.com>`_ from
    `Flaticon <https://www.flaticon.com/>`_ are licensed under
    `CC 3.0 BY <https://creativecommons.org/licenses/by/3.0/>`_.
+
+Pointless New Section
+---------------------
+You can ignore this.


### PR DESCRIPTION
Following Hacktoberfest's change to require submitted PRs to be approved in order to be valid, I wanted to test the results of the reviewDecision field of the PullRequest object in GitHub's GraphQL API by submitting a pull request and having it approved by people who were not maintainers, collaborators, or members of that repository.

The GitHub docs on the "reviewDecision" field for the [PullRequest object](https://docs.github.com/en/free-pro-team@latest/graphql/reference/objects#pullrequest) said:
> The current status of this pull request with respect to code review.

And the "APPROVED" state for the [PullRequestReviewDecision enum](https://docs.github.com/en/free-pro-team@latest/graphql/reference/enums#pullrequestreviewdecision) said:
> The pull request has received an approving review.

It looked to me like it would be possible for reviewDecision to be "APPROVED" even with an "approved" review that didn't result in mergeability (e.g., approvals from people who were not maintainers, collaborators, or members of that repository), but after testing this with the API, that does not appear to be the case.  The reviewDecision field _does_ appear to respect user permissions as described above.